### PR TITLE
Create and use default timeouts for the `requests` package

### DIFF
--- a/scraper/doecode/__init__.py
+++ b/scraper/doecode/__init__.py
@@ -3,6 +3,8 @@ import logging
 
 import requests
 
+from scraper.util import DEFAULT_REQUESTS_TIMEOUTS
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +34,11 @@ def process_url(url, key):
     if key is None:
         raise ValueError("DOE CODE API Key value is missing!")
 
-    response = requests.get(url, headers={"Authorization": "Basic " + key})
+    response = requests.get(
+        url,
+        headers={"Authorization": "Basic " + key},
+        timeout=DEFAULT_REQUESTS_TIMEOUTS,
+    )
     doecode_json = response.json()
 
     for record in doecode_json["records"]:

--- a/scraper/github/__init__.py
+++ b/scraper/github/__init__.py
@@ -8,6 +8,8 @@ import time
 import github3
 import requests
 
+from scraper.util import DEFAULT_REQUESTS_TIMEOUTS
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,7 +25,8 @@ def gov_orgs():
     us_gov_github_orgs = set()
 
     gov_orgs_json = requests.get(
-        "https://government.github.com/organizations.json"
+        "https://government.github.com/organizations.json",
+        timeout=DEFAULT_REQUESTS_TIMEOUTS,
     ).json()
 
     us_gov_github_orgs.update(gov_orgs_json["governments"]["U.S. Federal"])

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -14,6 +14,8 @@ import time
 import pytz
 import requests
 
+from scraper.util import DEFAULT_REQUESTS_TIMEOUTS
+
 
 def _vPrint(verbose, *args, **kwargs):
     """Easy verbosity-control print method.
@@ -490,10 +492,13 @@ class GitHubQueryManager:
                 "https://api.github.com/graphql",
                 data=gitqueryJSON,
                 headers={**authhead, **headers},
+                timeout=DEFAULT_REQUESTS_TIMEOUTS,
             )
         else:
             fullResponse = requests.get(
-                "https://api.github.com" + gitquery, headers={**authhead, **headers}
+                "https://api.github.com" + gitquery,
+                headers={**authhead, **headers},
+                timeout=DEFAULT_REQUESTS_TIMEOUTS,
             )
         _vPrint(
             verbose,

--- a/scraper/util.py
+++ b/scraper/util.py
@@ -8,6 +8,10 @@ import tempfile
 
 logger = logging.getLogger(__name__)
 
+# These mirror the defaults in github3.py sessions per:
+# https://github.com/sigmavirus24/github3.py/blob/ce43e6e5fdef6555f5a6b6602e2cc4b66c428aef/src/github3/session.py#L98
+DEFAULT_REQUESTS_TIMEOUTS = (4, 10)
+
 
 def execute(command, cwd=None):
     logger.debug("Forking command: %s", command)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds default connect and read timeout values to use for calls to the [requests] package. These are then used anywhere a [requests] call such as `get()`, `post()`, etc. are used as values for the `timeout` keyword argument.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [bandit 1.7.5](https://github.com/PyCQA/bandit/releases/tag/1.7.5) release included the following change: `add check for "requests" calls without timeout`. When testing this project with this version of [bandit] it flags medium severity warnings for all [requests] calls that do not have a `timeout` value provided (where one would be appropriate).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Testing locally passes. I also verified that the package works as expected when run against our GitHub organization.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[bandit]: https://pypi.org/project/bandit/
[requests]: https://pypi.org/project/requests/