### PR TITLE
Do not redirect `stderr` to `stdout` when executing commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements/production.txt") as fp:
 
 setup(
     name="llnl-scraper",
-    version="0.13.0-dev",
+    version="0.14.0-dev",
     description="Package for extracting software repository metadata",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `execute()` helper function to no longer redirect `stderr` to `stdout`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

If [cloc] has an issue processing a file it will output an error message to `stderr`, and with `stderr` and `stdout` combined this breaks the ability to read the JSON output on `stdout`. Since [cloc] is designed to process text files formatted for human consumption it will often error when processing minified JavaScript files of enough size, as the timeout for processing is based on the number of lines in a file. The error message(s) for such files then breaks the ability to get information about the rest of the project.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

On the `main` branch:

```console
2023-03-15 11:47:36,546 - INFO: Connected to: https://github.com
2023-03-15 11:47:36,977 - INFO: Processing: cisagov/cset
2023-03-15 11:49:44,728 - ERROR: Error Decoding: url=https://github.com/cisagov/cset.git, out=
3 errors:
Line count, exceeded timeout:  /tmp/tmph8eqj0h3/clone-dir/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/js/app.min.js
Line count, exceeded timeout:  /tmp/tmph8eqj0h3/clone-dir/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/math/extensions/a11y/mathjax-sre.js
Line count, exceeded timeout:  /tmp/tmph8eqj0h3/clone-dir/CSETWebNg/src/app/models/xmlCompletionItemProvider.model.ts
{"header" : {
  "cloc_url"           : "github.com/AlDanial/cloc",
  "cloc_version"       : "1.94",
<omitted>
"SUM": {
  "blank": 104009,
  "comment": 101199,
  "code": 1661696,
  "nFiles": 5391} }

2023-03-15 11:49:45,427 - INFO: SLOC: 0
2023-03-15 11:49:45,427 - INFO: labor_hours: 0
2023-03-15 11:49:46,045 - INFO: Number of Projects: 1
2023-03-15 11:49:46,047 - INFO: Writing output to: code.json
```

On this branch:

```console
2023-03-15 12:01:56,303 - INFO: Connected to: https://github.com
2023-03-15 12:01:56,725 - INFO: Processing: cisagov/cset
2023-03-15 12:04:23,443 - WARNING: Error encountered while analyzing: url=https://github.com/cisagov/cset.git stderr=
3 errors:
Line count, exceeded timeout:  /tmp/tmpc_di791i/clone-dir/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/js/app.min.js
Line count, exceeded timeout:  /tmp/tmpc_di791i/clone-dir/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/math/extensions/a11y/mathjax-sre.js
Line count, exceeded timeout:  /tmp/tmpc_di791i/clone-dir/CSETWebNg/src/app/models/xmlCompletionItemProvider.model.ts

2023-03-15 12:04:24,025 - INFO: SLOC: 1661696
2023-03-15 12:04:24,025 - INFO: labor_hours: 1555362
2023-03-15 12:04:24,468 - INFO: Number of Projects: 1
2023-03-15 12:04:24,468 - INFO: Writing output to: code.json
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cloc]: https://github.com/AlDanial/cloc
